### PR TITLE
Make short dates respect browser locale

### DIFF
--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -49,11 +49,17 @@ export default function NotificationItem({
                         `/@${thisAuthor.urlName}`
                         : `/@${thisUpdateUser.urlName}/${thisUpdate.url}`;
 
+                    const dateString = new Intl.DateTimeFormat(navigator.language, {
+                        day: "numeric",
+                        month: "numeric",
+                        year: "2-digit"
+                    }).format(new Date(thisUpdate.date));
+
                     if (notification.type === "comment") {
                         return (
                             <>
                                 <span>
-                                    <Link href={href}><a><b>{thisAuthor.name}</b> commented on your {format(new Date(thisUpdate.date), "M/d/yy")} update</a></Link>
+                                    <Link href={href}><a><b>{thisAuthor.name}</b> commented on your {dateString} update</a></Link>
                                 </span>
                             </>
                         );
@@ -69,7 +75,7 @@ export default function NotificationItem({
                                                     "their" :
                                                     thisUpdateUser.name + "'s"
                                         ) + " "}
-                                        {format(new Date(thisUpdate.date), "M/d/yy")} update</a></Link>
+                                        {dateString} update</a></Link>
                                 </span>
                                 <br/>
                                 <span className="opacity-50">
@@ -134,7 +140,7 @@ export default function NotificationItem({
                                 <div>
                                     <span>
                                         <b><Link href={href}><a>{thisAuthor.name} </a></Link></b>
-                                        <Link href={href}><a>liked your {format(new Date(thisUpdate.date), "M/d/yy")} update</a></Link>
+                                        <Link href={href}><a>liked your {dateString} update</a></Link>
                                     </span>
                                     <br/>
                                     <span className="opacity-50">
@@ -157,7 +163,7 @@ export default function NotificationItem({
                                                         "their" :
                                                         thisUpdateUser.name + "'s"
                                             ) + " "}
-                                            {format(new Date(thisUpdate.date), "M/d/yy")} update
+                                            {dateString} update
                                         </a>
                                     </Link>
                                 </span>
@@ -174,7 +180,7 @@ export default function NotificationItem({
                                 <div>
                                     <span>
                                         <b><Link href={href}><a>{thisAuthor.name} </a></Link></b>
-                                        <Link href={href}><a>mentioned you in their {format(new Date(thisUpdate.date), "M/d/yy")} update</a></Link>
+                                        <Link href={href}><a>mentioned you in their {dateString} update</a></Link>
                                     </span>
                                     <br/>
                                     <span className="opacity-50">
@@ -197,7 +203,7 @@ export default function NotificationItem({
                                                         "their" :
                                                         thisUpdateUser.name + "'s"
                                             ) + " "}
-                                            {format(new Date(thisUpdate.date), "M/d/yy")} update
+                                            {dateString} update
                                         </a>
                                     </Link>
                                 </span>

--- a/components/UpdateCommentItem.tsx
+++ b/components/UpdateCommentItem.tsx
@@ -121,7 +121,7 @@ export default function UpdateCommentItem({comment, mentionedUsers, update, user
                         </a>
                     </Link>
                     <span className="opacity-50 ml-4">
-                        {format(new Date(comment.createdAt), "M/d/yyyy 'at' h:mm a")}
+                        {new Intl.DateTimeFormat(navigator.language).format(new Date(comment.createdAt)) + format(new Date(comment.createdAt), " 'at' h:mm a")}
                     </span>
                 </p>
                 <CommentBody comment={comment} mentionedUsers={mentionedUsers}/>


### PR DESCRIPTION
Hi,

This PR changes all (?) short dates to be ordered according to the browser's locale. `date-fns` does have support for specifying a locale but their [documentation](https://date-fns.org/v1.9.0/docs/I18n) seems to want you to explicitly specify which locales you want to support and give a mapping between codes and locale objects? I didn't like the look of this (but let me know if you want me to change this to go down that route), so I used the built-in `Intl.DateTimeFormat` supported by all browsers.