### PR TITLE
fixing the update page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "updately",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "license": "BSD-3-Clause",
   "scripts": {

--- a/pages/[username]/[updateUrl].tsx
+++ b/pages/[username]/[updateUrl].tsx
@@ -169,7 +169,7 @@ export default function UpdatePage(props: { data: GetUpdateRequestResponse, upda
                     <>
                         <div className="flex">
                             <div className="mr-4 break-words overflow-hidden">
-                                <h1 className="up-h1 mb-4 dark:text-gray-300">{format(dateOnly(thisUpdate.date), "EEEE, MMMM d")}</h1>
+                                <h1 className="up-h1 mb-4 dark:text-gray-300">{format(dateOnly(thisUpdate.date), "EEEE, MMMM d, yyyy")}</h1>
                                 <h2 className="up-h2 dark:text-gray-300">{thisUpdate.title}</h2>
                                 {!!tags.length && (
                                     <div className="flex items-center my-8">

--- a/pages/[username]/[updateUrl].tsx
+++ b/pages/[username]/[updateUrl].tsx
@@ -172,7 +172,7 @@ export default function UpdatePage(props: { data: GetUpdateRequestResponse, upda
                     <>
                         <div className="flex">
                             <div className="mr-4 break-words overflow-hidden">
-                                <h1 className="up-h1 mb-4 dark:text-gray-300">{format(dateOnly(thisUpdate.date), "EEEE, MMMM d, yyyy")}</h1>
+                                <h1 className="up-h1 mb-4 dark:text-gray-300">{format(dateOnly(thisUpdate.date), "EEEE, MMMM d")}</h1>
                                 <h2 className="up-h2 dark:text-gray-300">{thisUpdate.title}</h2>
                                 {!!tags.length && (
                                     <div className="flex items-center my-8">
@@ -182,8 +182,8 @@ export default function UpdatePage(props: { data: GetUpdateRequestResponse, upda
                                     </div>
                                 )}
                                 <div className="mt-8 md:flex opacity-50 dark:text-gray-300 dark:opacity-75">
-                                    <p className="md:mr-12"><b>Created:</b> {format(new Date(thisUpdate.createdAt), "MMMM d 'at' h:mm a")}</p>
-                                    <p><b>Last edit:</b> {format(new Date(thisUpdate.updatedAt), "MMMM d 'at' h:mm a")}</p>
+                                    <p className="md:mr-12"><b>Created:</b> {format(new Date(thisUpdate.createdAt), "MMMM d, yyyy 'at' h:mm a")}</p>
+                                    <p><b>Last edit:</b> {format(new Date(thisUpdate.updatedAt), "MMMM d, yyyy 'at' h:mm a")}</p>
                                 </div>
                                 <div className="flex mt-6 items-center">
                                     <button

--- a/pages/[username]/[updateUrl].tsx
+++ b/pages/[username]/[updateUrl].tsx
@@ -132,6 +132,11 @@ export default function UpdatePage(props: { data: GetUpdateRequestResponse, upda
                 description={`${data.user.name}'s ${format(dateOnly(thisUpdate.date), "EEEE, MMMM d")} update${thisUpdate.title ? `: ${thisUpdate.title}` : ""} on Updately`}
             />
             <div className="max-w-3xl mx-auto px-4">
+                {!props.sidebarData && (
+                    <div className="my-16 bg-black p-4 text-white rounded">
+                        <p>This user's updates are unlisted and you accessed this update via direct link. Request to follow the user to see all of their updates.</p>
+                    </div>
+                )}
                 <div className="flex h-16 my-8 items-center sticky top-0 sm:top-16 bg-white z-20 dark:bg-gray-900">
                     <Link href={`/@${data.user.urlName}`}>
                         <a href="" className="flex items-center">
@@ -265,9 +270,11 @@ export default function UpdatePage(props: { data: GetUpdateRequestResponse, upda
                             </Link>
                         </div>
                     ))}
-                    {props.numUpdates > 20 && <p
-                    className="opacity-50 hover:opacity-100 transition mb-8 dark:opacity-75"
-                    ><a href={`/@${data.user.urlName}`}>View all {data.user.name.split(' ')[0]}'s {props.numUpdates} updates</a></p>}
+                    {props.sidebarData && props.numUpdates > 20 && (
+                        <p
+                            className="opacity-50 hover:opacity-100 transition mb-8 dark:opacity-75"
+                        ><a href={`/@${data.user.urlName}`}>View all {data.user.name.split(' ')[0]}'s {props.numUpdates} updates</a></p>
+                    )}
                 </div>
             </div>
         </div>
@@ -300,7 +307,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 	if (data === null) return { notFound: true };
 
 	const shouldHideSidebar = authorOfUpdate.private && !viewerFollowsAuthor;
-	const showDrafts = authorOfUpdate._id === viewer._id;
+	const showDrafts = !!viewer && (authorOfUpdate._id === viewer._id);
 	const sidebarData = shouldHideSidebar
 		? null
 		: await getSurroundingUpdateMetadata(

--- a/pages/api/update-metadata.ts
+++ b/pages/api/update-metadata.ts
@@ -1,0 +1,31 @@
+import { updateModel } from '../../models/models';
+import * as mongoose from 'mongoose';
+import { Update, UpdateMetadata } from '../../utils/types';
+
+
+export async function getSurroundingUpdateMetadata(authorId: string, updateUrl: string, showDrafts: boolean = false) {
+	await mongoose.connect(process.env.MONGODB_URL, {
+		useNewUrlParser: true,
+		useUnifiedTopology: true,
+		useFindAndModify: false,
+	});
+
+    const currentUpdate: Update = await updateModel.findOne({ url: updateUrl });
+    const projection = { $project: { date: 1, url: 1, title: 1, tags: 1, published: 1 } }
+	const updatesAfter: UpdateMetadata[] = await updateModel.aggregate([
+		{ $match: { date: { $gt: currentUpdate.date }, published: !showDrafts, userId: authorId} }, // date is after current update
+		{ $sort: { date: 1, _id: 1 } },
+		{ $limit: 2 },
+		projection,
+    ]);
+    
+    const updatesBefore: UpdateMetadata[] = await updateModel.aggregate([
+        { $match: { date: { $lt: currentUpdate.date }, published: !showDrafts, userId: authorId} }, // date is after current update
+		{ $sort: { date: -1, _id: 1 } },
+		{ $limit: 7 },
+		projection,
+    ])
+    // sorting is done client side
+    const result = updatesBefore.concat(currentUpdate, updatesAfter)
+    return result;
+}

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -8,7 +8,7 @@ import { SortBy, Update, User } from "./types";
 
 export interface GetUpdateRequestResponse {user: User, update: Update & {mentionedUsersArr: User[]}};
 
-export async function getUpdateRequest(username: string, url: string): Promise<GetUpdateRequestResponse> {
+export async function getUpdateRequest(username: string, url: string): Promise<GetUpdateRequestResponse | null> {
     await mongoose.connect(process.env.MONGODB_URL, {
         useNewUrlParser: true,
         useUnifiedTopology: true,
@@ -102,6 +102,36 @@ export async function getCurrUserRequest(email: string) {
     });
 
     return userModel.findOne({ email: email });
+}
+
+export async function getUserByEmail(email: string): Promise<User> {
+	await mongoose.connect(process.env.MONGODB_URL, {
+		useNewUrlParser: true,
+		useUnifiedTopology: true,
+		useFindAndModify: false,
+	});
+
+	return userModel.findOne({ email: email });
+}
+
+export async function getUserById(userId: string): Promise<User> {
+	await mongoose.connect(process.env.MONGODB_URL, {
+		useNewUrlParser: true,
+		useUnifiedTopology: true,
+		useFindAndModify: false,
+	});
+
+	return userModel.findOne({ _id: userId });
+}
+
+export async function getUserByUsername(username: string): Promise<User> {
+	await mongoose.connect(process.env.MONGODB_URL, {
+		useNewUrlParser: true,
+		useUnifiedTopology: true,
+		useFindAndModify: false,
+	});
+
+	return userModel.findOne({ urlName: username });
 }
 
 export async function getCurrUserFeedRequest(user, req) {

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -32,6 +32,23 @@ export async function getUpdateRequest(username: string, url: string): Promise<G
     };
 }
 
+export async function getNumberOfUpdates(
+	userId: string
+): Promise<{ estimatedDocumentCount: number }> {
+	await mongoose.connect(process.env.MONGODB_URL, {
+		useNewUrlParser: true,
+		useUnifiedTopology: true,
+		useFindAndModify: false,
+	});
+
+	const result = await updateModel.aggregate([
+		{ $match: { userId: userId, published: true } },
+		{ $count: 'estimatedDocumentCount' },
+    ]);
+	// array access is required because aggregates always return arrays
+    return result[0];
+}
+
 // Gets updates posted of a specific user
 export async function getUpdatesRequest({req}) {
     await mongoose.connect(process.env.MONGODB_URL, {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -40,6 +40,9 @@ export interface Update {
     tags: string[],
 }
 
+// obscure type system things:D
+export type UpdateMetadata = Pick<Update, '_id' | 'date' | 'url' | 'title' | 'tags' | 'published'>
+
 export interface PrivateAggregation {
     private: true,
     date: string, // date string


### PR DESCRIPTION
this PR changes the update page so that:

- the date includes the year (#97)
- the sidebar shows the updates around the current update, rather than the most recent (#98)
- update data is no longer sent if the author is true private
- the sidebar should be hidden if the viewer isn't logged in or doesn't follow the author (#79)

this comes along with some general readability/performance improvements — the update page no longer fetches any update data client side! 