### PR TITLE
minor pagination fix

### DIFF
--- a/components/PaginationBar.tsx
+++ b/components/PaginationBar.tsx
@@ -1,4 +1,5 @@
 import React, {Dispatch, SetStateAction} from "react";
+import { NUM_UPDATES_IN_PAGE } from "../utils/utils";
 
 export default function PaginationBar({page, count, label, setPage}: {
     page: number,
@@ -9,12 +10,12 @@ export default function PaginationBar({page, count, label, setPage}: {
     return (
         <>
             <p className="opacity-50 mt-16">
-                Showing {label} {(page - 1) * 10 + 1}
-                -{(page < Math.floor(count / 10)) ? page * 10 : count} of {count}
+                Showing {label} {(page - 1) * NUM_UPDATES_IN_PAGE + 1}
+                -{(page < Math.floor(count / NUM_UPDATES_IN_PAGE)) ? page * NUM_UPDATES_IN_PAGE : count} of {count}
             </p>
-            {count > 10 && (
+            {count > NUM_UPDATES_IN_PAGE && (
                 <div className="opacity-50 mt-4">
-                    {Array.from({length: Math.ceil(count / 10)}, (x, i) => i + 1).map(d => (
+                    {Array.from({length: Math.ceil(count / NUM_UPDATES_IN_PAGE)}, (x, i) => i + 1).map(d => (
                         <button
                             className={"py-2 px-4 rounded-md mr-2 " + (d === page ? "opacity-50 cursor-not-allowed bg-gray-200 dark:bg-neutral-700" : "")}
                             onClick={() => setPage(d)}

--- a/components/PaginationBar.tsx
+++ b/components/PaginationBar.tsx
@@ -12,7 +12,7 @@ export default function PaginationBar({page, count, label, setPage}: {
                 Showing {label} {(page - 1) * 10 + 1}
                 -{(page < Math.floor(count / 10)) ? page * 10 : count} of {count}
             </p>
-            {count > 20 && (
+            {count > 10 && (
                 <div className="opacity-50 mt-4">
                     {Array.from({length: Math.ceil(count / 10)}, (x, i) => i + 1).map(d => (
                         <button

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "updately",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "license": "BSD-3-Clause",
   "scripts": {

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -5,6 +5,7 @@ import short from "short-uuid";
 import { updateModel, userModel } from "../models/models";
 import getLookup from "./getLookup";
 import { SortBy, Update, User } from "./types";
+import { NUM_UPDATES_IN_PAGE } from "./utils";
 
 export interface GetUpdateRequestResponse {user: User, update: Update & {mentionedUsersArr: User[]}};
 
@@ -80,7 +81,7 @@ export async function getUpdatesRequest({req}) {
     if (req.query.date) conditions["date"] = new Date(req.query.date);
     
     const facetStage = {$facet: {
-        paginatedResults: [{$skip: (+req.query.page - 1) * 10}, {$limit: 10}],
+        paginatedResults: [{$skip: (+req.query.page - 1) * NUM_UPDATES_IN_PAGE}, {$limit: NUM_UPDATES_IN_PAGE}],
         totalCount: [{$count: "estimatedDocumentCount"}],
     }};
 

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -10,6 +10,8 @@ export function cleanForJSON(input: any): any {
 
 export const fetcher = url => fetch(url).then(res => res.json());
 
+export const NUM_UPDATES_IN_PAGE = 10;
+
 // from https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
 export function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string


### PR DESCRIPTION
the pagination component would only show pages if the number of updates was more than 20, but the api only serves 10 at a time — this meant that if a filter resulted in 10-19 updates, the extra updates wouldn't be shown and it would be impossible to page to see them.

fixed by making it a shared const.